### PR TITLE
ASM-4248 Zone configuration is skipping server's WWPN. And zone is not added to the zoneset

### DIFF
--- a/lib/puppet/provider/brocade_config/brocade_config.rb
+++ b/lib/puppet/provider/brocade_config/brocade_config.rb
@@ -66,12 +66,14 @@ Puppet::Type.type(:brocade_config).provide(:brocade_config, :parent => Puppet::P
   def create
     initialize_resources
     process_config_creation
+    transport.close
   end
 
   def destroy
     initialize_resources
     Puppet.debug(Puppet::Provider::Brocade_messages::CONFIG_DESTORY_DEBUG%[@config_name])
     destroy_config
+    transport.close
   end
 
   def exists?

--- a/lib/puppet/provider/brocade_config_membership/brocade_config_membership.rb
+++ b/lib/puppet/provider/brocade_config_membership/brocade_config_membership.rb
@@ -33,6 +33,7 @@ def check_member_present(response)
     return false
     end
   end
+  transport.close
   Puppet.info(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_ALREADY_EXIST_INFO%[@member_zone,@config_name])
   true
 end
@@ -45,6 +46,7 @@ def check_member_absent(response)
     return true
     end
   end
+  transport.close
   Puppet.info(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_ALREADY_REMOVED_INFO%[@member_zone,@config_name])
   false
 end
@@ -71,12 +73,14 @@ Puppet::Type.type(:brocade_config_membership).provide(:brocade_config_membership
     initialize_resources
     Puppet.debug(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_CREATE_DEBUG%[@member_zone,@config_name])
     config_add_zone
+    transport.close
   end
 
   def destroy
     initialize_resources
     Puppet.debug(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_DESTORY_DEBUG%[@member_zone,@config_name])
     config_remove_zone
+    transport.close
   end
 
   def exists?

--- a/lib/puppet/provider/brocade_config_membership/brocade_config_membership.rb
+++ b/lib/puppet/provider/brocade_config_membership/brocade_config_membership.rb
@@ -33,7 +33,6 @@ def check_member_present(response)
     return false
     end
   end
-  transport.close
   Puppet.info(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_ALREADY_EXIST_INFO%[@member_zone,@config_name])
   true
 end
@@ -46,7 +45,6 @@ def check_member_absent(response)
     return true
     end
   end
-  transport.close
   Puppet.info(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_ALREADY_REMOVED_INFO%[@member_zone,@config_name])
   false
 end

--- a/lib/puppet/provider/brocade_zone/brocade_zone.rb
+++ b/lib/puppet/provider/brocade_zone/brocade_zone.rb
@@ -23,6 +23,7 @@ Puppet::Type.type(:brocade_zone).provide(:brocade_zone, :parent => Puppet::Provi
     else
       cfg_save
     end
+    transport.close
   end
 
   def destroy
@@ -34,6 +35,7 @@ Puppet::Type.type(:brocade_zone).provide(:brocade_zone, :parent => Puppet::Provi
     else
       cfg_save
     end
+    transport.close
   end
 
   def exists?

--- a/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
+++ b/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
@@ -18,6 +18,7 @@ def create_zone_membership
   else
     cfg_save
   end
+  transport.close
 end
 
 def destroy_zone_membership
@@ -30,6 +31,7 @@ def destroy_zone_membership
   else
     cfg_save
   end
+  transport.close
 end
 
 def zone_membership_response_exists?(response)

--- a/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
+++ b/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
@@ -18,7 +18,6 @@ def create_zone_membership
   else
     cfg_save
   end
-  transport.close
 end
 
 def destroy_zone_membership
@@ -31,7 +30,6 @@ def destroy_zone_membership
   else
     cfg_save
   end
-  transport.close
 end
 
 def zone_membership_response_exists?(response)

--- a/lib/puppet_x/brocade/transport.rb
+++ b/lib/puppet_x/brocade/transport.rb
@@ -15,7 +15,7 @@ module PuppetX
         unless @session
           #Puppet already has ssh code that we can reuse, even though this isn't being used as a network device.
           require "puppet/util/network_device/transport/ssh"
-          @session = Puppet::Util::NetworkDevice::Transport::Ssh.new
+          @session = Puppet::Util::NetworkDevice::Transport::Ssh.new(true)
           @session.host = device_conf[:host]
           @session.port = device_conf[:port] || 22
 

--- a/spec/unit/puppet/provider/brocade_config/brocade_config_spec.rb
+++ b/spec/unit/puppet/provider/brocade_config/brocade_config_spec.rb
@@ -12,6 +12,7 @@ describe "Brocade_config" do
   before(:each) do
     @fixture = Brocade_config_fixture.new
     mock_transport=double('transport')
+    mock_transport.stub(:close)
     @fixture.provider.stub(:transport).and_return(mock_transport)
     @fixture.provider.stub(:cfg_save) 
     @fixture.provider.stub(:config_enable)      

--- a/spec/unit/puppet/provider/brocade_config_membership/brocade_config_membership_spec.rb
+++ b/spec/unit/puppet/provider/brocade_config_membership/brocade_config_membership_spec.rb
@@ -7,6 +7,7 @@ describe "Brocade Config Membership Provider" do
   before(:each) do
     @fixture = Brocade_config_membership_fixture.new
     mock_transport=double('transport')
+    mock_transport.stub(:close)
     @fixture.provider.stub(:transport).and_return(mock_transport)
     Puppet.stub(:info)
     Puppet.stub(:debug)

--- a/spec/unit/puppet/provider/brocade_zone/brocade_zone_spec.rb
+++ b/spec/unit/puppet/provider/brocade_zone/brocade_zone_spec.rb
@@ -6,6 +6,7 @@ describe "Brocade Zone behavior testing" do
   before(:each) do
     @fixture = Brocade_zone_fixture.new
     mock_transport=double('transport')
+    mock_transport.stub(:close)
     @fixture.provider.stub(:transport).and_return(mock_transport)
     @fixture.provider.stub(:cfg_save)
   end

--- a/spec/unit/puppet/provider/brocade_zone_membership/brocade_zone_membership_spec.rb
+++ b/spec/unit/puppet/provider/brocade_zone_membership/brocade_zone_membership_spec.rb
@@ -7,6 +7,7 @@ describe "Brocade Zone Membership Provider" do
   before(:each) do
     @fixture = Brocade_zone_membership_fixture.new
     mock_transport=double('transport')
+    mock_transport.stub(:close)
     @fixture.provider.stub(:transport).and_return(mock_transport)
     Puppet.stub(:info)
     Puppet.stub(:debug)


### PR DESCRIPTION
Due to recent refactoring changes, transport is getting initiatlized for each of the resource invocation. There is a limit on the number of connections that we can open on Brocade switch (2).
To take care of the connection pool, added connection close call (transport.close) in create and destroy methods of the resources used by ASM