### PR TITLE
ASM-4314  Brocade zone configuration is failing in case of multiple servers

### DIFF
--- a/lib/puppet/provider/brocade_config/brocade_config.rb
+++ b/lib/puppet/provider/brocade_config/brocade_config.rb
@@ -80,9 +80,9 @@ Puppet::Type.type(:brocade_config).provide(:brocade_config, :parent => Puppet::P
     initialize_resources
     response = transport.command(Puppet::Provider::Brocade_commands::CONFIG_SHOW_COMMAND%[@config_name], :noop => false)
     if ( response.include? Puppet::Provider::Brocade_responses::RESPONSE_DOES_NOT_EXIST )
-    false
+      false
     else
-    true
+      true
     end
   end
 
@@ -109,6 +109,7 @@ Puppet::Type.type(:brocade_config).provide(:brocade_config, :parent => Puppet::P
   def configstate=(value)
     initialize_resources
     process_config_state(value)
+    transport.close
   end
 end
 

--- a/lib/puppet/provider/brocade_config_membership/brocade_config_membership.rb
+++ b/lib/puppet/provider/brocade_config_membership/brocade_config_membership.rb
@@ -30,10 +30,11 @@ def check_member_present(response)
   @member_zone.split(";").each do |member|
     if !(response.include? member)
       Puppet.info(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_ADD_INFO%[member, @config_name])
-    return false
+      return false
     end
   end
   Puppet.info(Puppet::Provider::Brocade_messages::CONFIG_MEMBERSHIP_ALREADY_EXIST_INFO%[@member_zone,@config_name])
+  transport.close
   true
 end
 
@@ -86,12 +87,13 @@ Puppet::Type.type(:brocade_config_membership).provide(:brocade_config_membership
     response = transport.command(Puppet::Provider::Brocade_commands::CONFIG_SHOW_COMMAND%[@config_name], :noop => false)
     if ("#{@resource[:ensure]}"== "present")
       if (config_membership_response_exists?(response))
-      return true
+        transport.close
+        return true
       end
       check_member_present(response)
     else
       if (config_membership_response_exists?(response))
-      return false
+        return false
       end
       check_member_absent(response)
     end

--- a/lib/puppet/provider/brocade_zone/brocade_zone.rb
+++ b/lib/puppet/provider/brocade_zone/brocade_zone.rb
@@ -39,9 +39,14 @@ Puppet::Type.type(:brocade_zone).provide(:brocade_zone, :parent => Puppet::Provi
   end
 
   def exists?
+    Puppet.debug("Inside create zone exists block")
     initialize_resources
     Puppet.debug(Puppet::Provider::Brocade_messages::ZONE_EXISTS_DEBUG%[@zone_name])
     response =  transport.command("zoneshow #{@zone_name}", :noop => false)
+    unless response.include? Puppet::Provider::Brocade_responses::RESPONSE_DOES_NOT_EXIST
+      Puppet.debug("Closing connection, as zone already exists")
+      transport.close
+    end
     !response.include? Puppet::Provider::Brocade_responses::RESPONSE_DOES_NOT_EXIST
   end
 

--- a/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
+++ b/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
@@ -37,9 +37,9 @@ end
 def zone_membership_response_exists?(response)
   if (response.include? Puppet::Provider::Brocade_responses::RESPONSE_DOES_NOT_EXIST)
     Puppet.info(Puppet::Provider::Brocade_messages::ZONE_DOES_NOT_EXIST_INFO%[@zone_name])
-  return true
+    return true
   else
-  return false
+    return false
   end
 end
 
@@ -47,7 +47,7 @@ def zone_membership_response_includes_wwpn?(response)
   return_value = true
   @member_name.split(";").each do |wwpn|
     if !(response.include? wwpn)
-    return_value = false
+      return_value = false
     end
   end
   return return_value
@@ -55,12 +55,14 @@ end
 
 def zone_membership_exists_when_ensure_present(response)
   if (zone_membership_response_exists?(response))
-  return true
+    return true
   end
   if !(zone_membership_response_includes_wwpn?(response))
-  return false
+    return false
   end
   Puppet.info(Puppet::Provider::Brocade_messages::ZONE_MEMBERSHIP_ALREADY_EXIST_INFO%[@member_name,@zone_name])
+  Puppet.debug("Closing connection, member already exists")
+  transport.close
   return true
 
 end
@@ -100,6 +102,7 @@ Puppet::Type.type(:brocade_zone_membership).provide(:brocade_zone_membership, :p
 
   def exists?
     initialize_resources
+    Puppet.debug("Inside zone membership exists block")
     response = transport.command(Puppet::Provider::Brocade_commands::ZONE_SHOW_COMMAND%[@zone_name], :noop => false)
     if("#{@resource[:ensure]}"== "present")
       return zone_membership_exists_when_ensure_present(response)


### PR DESCRIPTION
Added the transport.close in the exists operation where we are returning success for existence of the resource. This was leading to the connection leak as transport.close was added only for the create and destroy operations