### PR TITLE
ASM-3406 remove asm_decrypt password encryption

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -16,19 +16,17 @@ opts = Trollop::options do
   opt :username, 'switch username', :type => :string
   opt :password, 'switch password', :type => :string
   opt :timeout, 'command timeout', :default => 240
-  opt :credential_id, 'credential id in database', :type => :string
-  opt :asm_decrypt, 'dummy value for ASM, not used'
   opt :community_string, 'dummy value for ASM, not used'
 end
 
 begin
-  if (opts[:username].nil? || opts[:password].nil?) && opts[:credential_id].nil?
-    puts "Must give username and password parameters, or a valid credential id parameter."
+  if opts[:username].nil? || opts[:password].nil?
+    puts "Must give username and password parameters."
     exit 1
   end
   Timeout.timeout(opts[:timeout]) do
     device_conf = {:scheme => 'ssh', :host => opts[:server], :port => opts[:port], :password => opts[:password],
-                   :user=>opts[:username], :arguments=>{ :credential_id => opts[:credential_id] } }
+                   :user=>opts[:username] }
     transport = PuppetX::Brocade::Transport.new(nil, {:device_config => device_conf})
     facts = transport.facts
   end


### PR DESCRIPTION
An encrypted device password was passed to the asm-deployer device
management service and written to the device configuration file
url. That password has been deprecated and all puppet-layer code
should use the credential_id argument in preference to that.

Additionally the credential-id argument will no longer be passed to
inventory scripts since it is redundant -- the information contained
in it is already passed as separate plaintext arguments.