### PR TITLE
ASM-4676 ASM is sipping zone configuration for the deployment having more than 6 servers

### DIFF
--- a/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
+++ b/lib/puppet/provider/brocade_zone_membership/brocade_zone_membership.rb
@@ -55,6 +55,7 @@ end
 
 def zone_membership_exists_when_ensure_present(response)
   if (zone_membership_response_exists?(response))
+    transport.close
     return true
   end
   if !(zone_membership_response_includes_wwpn?(response))

--- a/lib/puppet/type/brocade_config.rb
+++ b/lib/puppet/type/brocade_config.rb
@@ -5,10 +5,19 @@ Puppet::Type.newtype(:brocade_config) do
 
   ensurable
 
+  newparam(:name, :namevar => true) do
+    desc "This parameter is tuple of alias name and member perameter"
+
+    munge do |value|
+      @resource[:zone_name], @resource[:configname] = value.split(':',2)
+      value
+    end
+  end
+
   newparam(:configname) do
     desc "This parameter describes the config name on Brocade
           The valid config name does not allow blank value,special character except _ ,numeric char at the start, and length above 64 chars"
-    isnamevar
+
     validate do |value|
       Puppet::Type::Brocade_messages.empty_value_check(value, Puppet::Type::Brocade_messages::CONFIG_NAME_BLANK_ERROR)
       Puppet::Type::Brocade_messages.special_char_check(value, Puppet::Type::Brocade_messages::CONFIG_NAME_SPECIAL_CHAR_ERROR)
@@ -16,6 +25,10 @@ Puppet::Type.newtype(:brocade_config) do
       Puppet::Type::Brocade_messages.long_name_check(value, Puppet::Type::Brocade_messages::CONFIG_NAME_LONG_ERROR)
     end
   end
+
+  newparam(:zone_name) do
+  end
+
 
   newparam(:member_zone) do
     desc "This parameter describes the zone in the config

--- a/manifests/createzone.pp
+++ b/manifests/createzone.pp
@@ -49,19 +49,18 @@ define brocade::createzone (
         ensure => "present",
     }
 
-    if !defined(Brocade_config["$zoneset"]) {
-      brocade_config {
-        "$zoneset":
-          ensure      => "present",
-          member_zone => "$name",
-          configstate => "enable",
-      }
+    brocade_config {
+      "$name:$zoneset":
+        ensure      => "present",
+        member_zone => "$name",
+        configstate => "enable",
     }
 
     Brocade_zone["$name"]
+    -> Brocade_zone_membership["$name:$storage_alias"]
     -> Brocade_zone_membership["$name:$server_wwn"]
     -> Brocade_config_membership["$zoneset:$name"]
-    -> Brocade_config["$zoneset"]
+    -> Brocade_config["$name:$zoneset"]
 }
 
 

--- a/spec/fixtures/unit/puppet/provider/brocade_config/brocade_config_fixture.rb
+++ b/spec/fixtures/unit/puppet/provider/brocade_config/brocade_config_fixture.rb
@@ -10,10 +10,11 @@ class Brocade_config_fixture
 
   def  get_brocade_config
     Puppet::Type.type(:brocade_config).new(
-    :configname => 'DemoConfig',
-    :ensure => 'present',
-    :member_zone => 'DemoZone',
-    :configstate => 'disable',
+        :name => 'zonename:DemoConfig',
+        :configname => 'DemoConfig',
+        :ensure => 'present',
+        :member_zone => 'DemoZone',
+        :configstate => 'disable',
     )
   end
 
@@ -39,3 +40,4 @@ class Brocade_config_fixture
     brocade_config[:ensure] = 'absent'
   end
 end
+

--- a/spec/unit/puppet/type/brocade_config_spec.rb
+++ b/spec/unit/puppet/type/brocade_config_spec.rb
@@ -5,10 +5,11 @@ describe Puppet::Type.type(:brocade_config) do
 
   context 'should compile with given test params' do
     let(:params) { {
+        :name         => 'zonename:DemoConfig',
         :configname   => 'DemoConfig',
         :member_zone   => 'DemoMemberZone',
         :configstate   => 'enable',
-      }}
+    }}
     it do
       expect {
         should compile
@@ -19,7 +20,7 @@ describe Puppet::Type.type(:brocade_config) do
 
   context "when validating attributes" do
     it "should have configname as one of its parameters for config name" do
-      described_class.key_attributes.should == [:configname]
+      described_class.key_attributes.should == [:name]
     end
 
     describe "when validating attributes type" do
@@ -42,27 +43,27 @@ describe Puppet::Type.type(:brocade_config) do
     describe "validating configname variable" do
 
       it "should support an alphanumerical name" do
-        described_class.new(:configname   => 'DemoConfig1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')[:configname].should == 'DemoConfig1'
+        described_class.new(:name => 'zonename:DemoConfig1', :configname   => 'DemoConfig1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')[:configname].should == 'DemoConfig1'
       end
 
       it "should support underscores" do
-        described_class.new(:configname   => 'DemoConfig_1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')[:configname].should == 'DemoConfig_1'
+        described_class.new(:name => 'zonename:DemoConfig1', :configname   => 'DemoConfig_1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')[:configname].should == 'DemoConfig_1'
       end
 
       it "should not support blank value" do
-        expect { described_class.new(:configname   => '', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig1', :configname   => '', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
 
       it "should not support special characters" do
-        expect { described_class.new(:configname   => 'DemoCon@#fig_1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig1', :configname   => 'DemoCon@#fig_1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
 
       it "should not support numeric value at the start of the string" do
-        expect { described_class.new(:configname   => '1DemoConfig1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig1', :configname   => '1DemoConfig1', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
-      
+
       it "should not support  long name (64 characters maximum limit)" do
-        expect { described_class.new(:configname   => 'abcdefghijknlmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz123456789012', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig1', :configname   => 'abcdefghijknlmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz123456789012', :member_zone   => 'DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
 
 
@@ -71,25 +72,25 @@ describe Puppet::Type.type(:brocade_config) do
     describe "validating member_zone variable" do
 
       it "should support an alphanumerical name" do
-        described_class.new(:configname   => 'DemoConfig', :member_zone   => 'DemoMemberZone1', :configstate   => 'enable', :ensure => 'present')[:member_zone].should == 'DemoMemberZone1'
+        described_class.new(:name => 'zonename:DemoConfig',:configname   => 'DemoConfig', :member_zone   => 'DemoMemberZone1', :configstate   => 'enable', :ensure => 'present')[:member_zone].should == 'DemoMemberZone1'
       end
 
       it "should support underscores" do
-        described_class.new(:configname   => 'DemoConfig', :member_zone   => 'DemoMemberZone_1', :configstate   => 'enable', :ensure => 'present')[:member_zone].should == 'DemoMemberZone_1'
+        described_class.new(:name => 'zonename:DemoConfig', :configname   => 'DemoConfig', :member_zone   => 'DemoMemberZone_1', :configstate   => 'enable', :ensure => 'present')[:member_zone].should == 'DemoMemberZone_1'
       end
 
       it "should not support blank value" do
-        expect { described_class.new(:configname   => 'DemoConfig', :member_zone   => '', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig', :configname   => 'DemoConfig', :member_zone   => '', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
 
       it "should not support special characters" do
-        expect { described_class.new(:configname   => 'DemoConfig', :member_zone   => 'DemoMember@#Zone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig', :configname   => 'DemoConfig', :member_zone   => 'DemoMember@#Zone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
 
       it "should not support numeric character at the beginning of the zone name" do
-        expect { described_class.new(:configname   => 'DemoConfig', :member_zone   => '1DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig', :configname   => 'DemoConfig', :member_zone   => '1DemoMemberZone', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
-      
+
       it "should not support  long name (64 characters maximum limit)" do
         expect { described_class.new(:configname   => 'Democonfig', :member_zone   => 'abcdefghijknlmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz123456789012', :configstate   => 'enable', :ensure => 'present')}.to raise_error Puppet::Error
       end
@@ -99,33 +100,32 @@ describe Puppet::Type.type(:brocade_config) do
 
     describe "when validating configstate property" do
       it "should support enable" do
-        described_class.new(:configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'enable', :ensure => 'present')[:configstate].should == :enable
+        described_class.new(:name => 'zonename:DemoConfig', :configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'enable', :ensure => 'present')[:configstate].should == :enable
       end
 
       it "should support disable" do
-        described_class.new(:configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'disable', :ensure => 'absent')[:configstate].should == :disable
+        described_class.new(:name => 'zonename:DemoConfig', :configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'disable', :ensure => 'absent')[:configstate].should == :disable
       end
 
       it "should not support other values" do
-        expect { described_class.new(:configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'negativetest', :ensure => 'absent') }.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig', :configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'negativetest', :ensure => 'absent') }.to raise_error Puppet::Error
       end
-      
+
     end
 
     describe "when validating ensure property" do
       it "should support present" do
-        described_class.new(:configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'enable', :ensure => 'present')[:ensure].should == :present
+        described_class.new(:name => 'zonename:DemoConfig', :configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'enable', :ensure => 'present')[:ensure].should == :present
       end
 
       it "should support absent" do
-        described_class.new(:configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'disable', :ensure => 'absent')[:ensure].should == :absent
+        described_class.new(:name => 'zonename:DemoConfig', :configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'disable', :ensure => 'absent')[:ensure].should == :absent
       end
 
       it "should not support other values" do
-        expect { described_class.new(:configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'disable', :ensure => 'negativetest') }.to raise_error Puppet::Error
+        expect { described_class.new(:name => 'zonename:DemoConfig', :configname => 'DemoConfig', :member_zone => 'DemoMemberZone', :configstate => 'disable', :ensure => 'negativetest') }.to raise_error Puppet::Error
       end
     end
 
   end
 end
-


### PR DESCRIPTION
Connection close command was missing in case the zone exists and the zonemember that needs to be added also exists in the switch configuration.
Manifest and brocade_config is updated to support serialize configuration of multiple zone configuration