### PR TITLE
ASM-5646 FC deployments failing cause inventory is timing out with 'zoneshow' command

### DIFF
--- a/lib/puppet_x/brocade/possible_facts/base.rb
+++ b/lib/puppet_x/brocade/possible_facts/base.rb
@@ -228,8 +228,10 @@ module PuppetX::Brocade::PossibleFacts
           switch_name = base.facts['Switch Name'].value
           zones.split(',').each do |zone_val|
             zone_val.strip!
+            pattern = "zone:\s+#{zone_val}(.*?)(zone:|alias:|Effective configuration:)"
+            zone_detail = txt.scan(/#{pattern}/m)
+            output = zone_detail[0].flatten.first.strip
             zone_members[zone_val] = []
-            output = base.transport.command("zoneshow \"#{zone_val}\"")
             output.split("\n").each do |line|
               next if line.match(/zoneshow|zone:|#{switch_name}:/)
               item=(line.scan(/\S+/).flatten || []).first


### PR DESCRIPTION
Removed "zoneshow <zone name>" command for each zone for getting the zone membership and used zoneshow command to get the required details. This has reduced the the discovery time back to same as before.