### PR TITLE
ASM-5692 Brocade Switch Discovery Failing on Build 5587

### DIFF
--- a/lib/puppet_x/brocade/possible_facts/base.rb
+++ b/lib/puppet_x/brocade/possible_facts/base.rb
@@ -228,8 +228,9 @@ module PuppetX::Brocade::PossibleFacts
           switch_name = base.facts['Switch Name'].value
           zones.split(',').each do |zone_val|
             zone_val.strip!
-            pattern = "zone:\s+#{zone_val}(.*?)(zone:|alias:|Effective configuration:)"
+            pattern = "zone:\\s+#{zone_val}(.*?)(zone:|alias:|Effective configuration:)"
             zone_detail = txt.scan(/#{pattern}/m)
+            next if zone_detail.nil? || zone_detail.empty?
             output = zone_detail[0].flatten.first.strip
             zone_members[zone_val] = []
             output.split("\n").each do |line|


### PR DESCRIPTION
- Pattern used for finding the zone information was not optimized
- Skip zones where we done have any members in it