### PR TITLE
ASM-5864: Improve Zone Member parsing

### DIFF
--- a/lib/puppet_x/brocade/possible_facts/base.rb
+++ b/lib/puppet_x/brocade/possible_facts/base.rb
@@ -235,11 +235,10 @@ module PuppetX::Brocade::PossibleFacts
             zone_members[zone_val] = []
             output.split("\n").each do |line|
               next if line.match(/zoneshow|zone:|#{switch_name}:/)
-              item=(line.scan(/\S+/).flatten || []).first
-              if item.nil? || item.empty? || item =~ /^\s+$/ then
+              if line.nil? || line.empty? || line =~ /^\s+$/ then
                 next
               else
-                item.split(';').each do  |i|
+                line.split(';').each do  |i|
                   i.strip!
                   if alias_members[i].nil?
                     zone_members[zone_val].push(i)


### PR DESCRIPTION
Some zone members were not added, this improves the parsing to cover
them all