### PR TITLE
ASM-5864: Detect and surpress blank wwpns

### DIFF
--- a/lib/puppet_x/brocade/possible_facts/base.rb
+++ b/lib/puppet_x/brocade/possible_facts/base.rb
@@ -240,6 +240,8 @@ module PuppetX::Brocade::PossibleFacts
               else
                 line.split(';').each do  |i|
                   i.strip!
+                  next if i.empty?
+
                   if alias_members[i].nil?
                     zone_members[zone_val].push(i)
                   else


### PR DESCRIPTION
Some brocade lines end in a "; " like:

   'Compellent_Bottom; 20:01:00:0a:f7:06:ba:f5; '

this resulted in a blank wwpn being added to the facts, this detects
those and does not add them to the final list.