### PR TITLE
ASM-5847: Correctly parse port numbers.

### DIFF
--- a/lib/puppet_x/brocade/possible_facts/custom.rb
+++ b/lib/puppet_x/brocade/possible_facts/custom.rb
@@ -16,7 +16,7 @@ module PuppetX::Brocade::PossibleFacts::Custom
       ports=nil
       match do |txt|
         txt.split(/portIndex:\s+(.*)/).each do |text|
-          location=text.scan(/portName: port(.\w)/).flatten.first
+          location=text.scan(/portName: port\s*(\d+)/)).flatten.first
           if !(location.nil? || location.empty?)
             ports=Hash.new
             macadd=text.scan(/portWwn of device\(s\) connected:\s(.*)Distance/m).flatten.first.strip


### PR DESCRIPTION
A previous attempt in ASM-5873 tried to turn the detected port numbers
from "port1" to "1" but made it so only ports >= 10 were detected.

This improves the Regex used.