### PR TITLE
ASM-6521, ASM-6522 Make discovery scripts recognize credential_id

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -17,6 +17,7 @@ opts = Trollop::options do
   opt :password, 'switch password', :type => :string, :default => ENV['PASSWORD']
   opt :timeout, 'command timeout', :default => 240
   opt :community_string, 'dummy value for ASM, not used'
+  opt :credential_id, 'dummy value for ASM, not used'
   opt :output, 'output facts to a file', :type => :string, :required => true
 end
 


### PR DESCRIPTION
To support server and chassis discovery scripts to accept credential_id as parameter, ASM deployer's run_script will pass credential_id as command line arguments to any discovery scripts (similar to passing other generic arguments like username,password,output,community)string).

This means Trollop of the discovery scripts needs to declare accepting credential_id param, even if it is no-op.