### PR TITLE
ASM-7126 #<RuntimeError: No controllers found for vnx-apm00153616382>

### DIFF
--- a/lib/puppet_x/brocade/possible_facts/base.rb
+++ b/lib/puppet_x/brocade/possible_facts/base.rb
@@ -201,14 +201,10 @@ module PuppetX::Brocade::PossibleFacts
             alias_val.strip!
             alias_members[alias_val] = []
             output = base.transport.command("alishow #{alias_val}")
-            output.split("\n").each do |line|
-              next if line.match(/alishow|alias:|#{switch_name}:/)
-              item=line.scan(/\S+/).flatten
-              if item.nil? || item.empty? || item =~ /^\s+$/ then
-                next
-              else
-                item.collect {|i| alias_members[alias_val].push(i.gsub(/;/,'')) }
-              end
+            alias_data = (output.scan(/alias:\s*#{alias_val}(.*)$/m) || []).first.first
+            if alias_data
+              alias_mems = alias_data.scan(/(([0-9a-f]{1,2}[\.:-]){7}([0-9a-f]{1,2}))/mi)
+              alias_members[alias_val] = alias_mems.collect {|x| x[0]}
             end
           end
           alias_members.to_json


### PR DESCRIPTION
Alias members identification code was not able to find all alias members consistently. In case there are multiple alias mapped to a nameserver entry then we look for a alias having more than one alias member.
Due the bug in alias member identification code was failing while looking for controller alias name.