### PR TITLE
ASM-7972 Support for Brocade 8.X FOS

### DIFF
--- a/lib/puppet_x/brocade/possible_facts/base.rb
+++ b/lib/puppet_x/brocade/possible_facts/base.rb
@@ -258,7 +258,7 @@ module PuppetX::Brocade::PossibleFacts
         match do |txt|
           alias_members = JSON.parse(base.facts['Aliases_Members'].value)
           Puppet.debug("Alias Members: #{alias_members}")
-          match_array=txt.scan(/N\s+(\w+);(.*)\s+\w+:.*\s+(.*)\s+.*\s+.*\s+Permanent Port Name:\s+(\S+)\s+Device type:\s+(.*)\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*\s+Aliases:(.*)/)
+          match_array=txt.scan(/N\s+(\w+);(.*)\s+\w+:.*\s+(.*)\s+.*\s+.*\s+Permanent Port Name:\s+(\S+)\s+Device type:\s+(.*)\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*\s+Aliases:(.*)/)
           Puppet.debug"match_array: #{match_array.inspect}"
           if !match_array.empty?
             match_array.each do |nameserverinfo|


### PR DESCRIPTION
8.x Nameserver data was returning additional 
information "Device link speed: 8G". Old regex 
written for 6 fields. When updated brocade 
returns 7 fields, regex was failing to process.

Changed the regex to process new field as well.